### PR TITLE
Add simple approval module

### DIFF
--- a/Modules/Approval/App/Http/Controllers/ApprovalController.php
+++ b/Modules/Approval/App/Http/Controllers/ApprovalController.php
@@ -14,7 +14,7 @@ class ApprovalController extends Controller
      */
     public function index()
     {
-        $items = ApprovalItem::all();
+        $items = ApprovalItem::with('approvalStatus')->get();
 
         return view('approval::index', compact('items'));
     }

--- a/Modules/Approval/App/Http/Controllers/ApprovalController.php
+++ b/Modules/Approval/App/Http/Controllers/ApprovalController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Modules\Approval\App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Modules\Approval\App\Models\ApprovalItem;
+
+class ApprovalController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $items = ApprovalItem::all();
+
+        return view('approval::index', compact('items'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('approval::create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        $validated['user_id'] = Auth::id();
+
+        $item = ApprovalItem::create($validated);
+
+        return redirect()->route('approval.items.show', $item);
+    }
+
+    /**
+     * Show the specified resource.
+     */
+    public function show($id)
+    {
+        $item = ApprovalItem::findOrFail($id);
+
+        return view('approval::show', compact('item'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit($id)
+    {
+        $item = ApprovalItem::findOrFail($id);
+
+        return view('approval::edit', compact('item'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, $id)
+    {
+        $item = ApprovalItem::findOrFail($id);
+
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        $item->update($validated);
+
+        return redirect()->route('approval.items.show', $item);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy($id)
+    {
+        $item = ApprovalItem::findOrFail($id);
+        $item->delete();
+
+        return redirect()->route('approval.items.index');
+    }
+}

--- a/Modules/Approval/App/Models/ApprovalItem.php
+++ b/Modules/Approval/App/Models/ApprovalItem.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Modules\Approval\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use RingleSoft\LaravelProcessApproval\Contracts\ApprovableModel;
+use RingleSoft\LaravelProcessApproval\Traits\Approvable;
+
+class ApprovalItem extends Model implements ApprovableModel
+{
+    use HasFactory, Approvable;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'user_id',
+    ];
+
+    public function bypassApprovalProcess(): bool
+    {
+        return false;
+    }
+
+    public function enableAutoSubmit(): bool
+    {
+        return true;
+    }
+
+    public static function getApprovableType(): string
+    {
+        return self::class;
+    }
+
+    public static function approvalFlow(): ?\RingleSoft\LaravelProcessApproval\Models\ProcessApprovalFlow
+    {
+        return \RingleSoft\LaravelProcessApproval\Models\ProcessApprovalFlow::query()
+            ->where('approvable_type', static::class)
+            ->first();
+    }
+
+    public function onApprovalCompleted(\RingleSoft\LaravelProcessApproval\Models\ProcessApproval $approval): bool
+    {
+        // Called when approval is completed; return true to finalize
+        return true;
+    }
+}

--- a/Modules/Approval/App/Providers/ApprovalServiceProvider.php
+++ b/Modules/Approval/App/Providers/ApprovalServiceProvider.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Modules\Approval\App\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\ServiceProvider;
+use Nwidart\Modules\Traits\PathNamespace;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class ApprovalServiceProvider extends ServiceProvider
+{
+    use PathNamespace;
+
+    protected string $name = 'Approval';
+
+    protected string $nameLower = 'approval';
+
+    /**
+     * Boot the application events.
+     */
+    public function boot(): void
+    {
+        $this->registerCommands();
+        $this->registerCommandSchedules();
+        $this->registerTranslations();
+        $this->registerConfig();
+        $this->registerViews();
+        $this->loadMigrationsFrom(module_path($this->name, 'database/migrations'));
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register(): void
+    {
+        $this->app->register(EventServiceProvider::class);
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    /**
+     * Register commands in the format of Command::class
+     */
+    protected function registerCommands(): void
+    {
+        // $this->commands([]);
+    }
+
+    /**
+     * Register command Schedules.
+     */
+    protected function registerCommandSchedules(): void
+    {
+        // $this->app->booted(function () {
+        //     $schedule = $this->app->make(Schedule::class);
+        //     $schedule->command('inspire')->hourly();
+        // });
+    }
+
+    /**
+     * Register translations.
+     */
+    public function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/'.$this->nameLower);
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, $this->nameLower);
+            $this->loadJsonTranslationsFrom($langPath);
+        } else {
+            $this->loadTranslationsFrom(module_path($this->name, 'lang'), $this->nameLower);
+            $this->loadJsonTranslationsFrom(module_path($this->name, 'lang'));
+        }
+    }
+
+    /**
+     * Register config.
+     */
+    protected function registerConfig(): void
+    {
+        $relativeConfigPath = config('modules.paths.generator.config.path');
+        $configPath = module_path($this->name, $relativeConfigPath);
+
+        if (is_dir($configPath)) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($configPath));
+
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    $relativePath = str_replace($configPath . DIRECTORY_SEPARATOR, '', $file->getPathname());
+                    $configKey = $this->nameLower . '.' . str_replace([DIRECTORY_SEPARATOR, '.php'], ['.', ''], $relativePath);
+                    $key = ($relativePath === 'config.php') ? $this->nameLower : $configKey;
+
+                    $this->publishes([$file->getPathname() => config_path($relativePath)], 'config');
+                    $this->mergeConfigFrom($file->getPathname(), $key);
+                }
+            }
+        }
+    }
+
+    /**
+     * Register views.
+     */
+    public function registerViews(): void
+    {
+        $viewPath = resource_path('views/modules/'.$this->nameLower);
+        $sourcePath = module_path($this->name, 'resources/views');
+
+        $this->publishes([$sourcePath => $viewPath], ['views', $this->nameLower.'-module-views']);
+
+        $this->loadViewsFrom(array_merge($this->getPublishableViewPaths(), [$sourcePath]), $this->nameLower);
+
+        $componentNamespace = $this->module_namespace($this->name, $this->app_path(config('modules.paths.generator.component-class.path')));
+        Blade::componentNamespace($componentNamespace, $this->nameLower);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     */
+    public function provides(): array
+    {
+        return [];
+    }
+
+    private function getPublishableViewPaths(): array
+    {
+        $paths = [];
+        foreach (config('view.paths') as $path) {
+            if (is_dir($path.'/modules/'.$this->nameLower)) {
+                $paths[] = $path.'/modules/'.$this->nameLower;
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/Modules/Approval/App/Providers/EventServiceProvider.php
+++ b/Modules/Approval/App/Providers/EventServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Modules\Approval\App\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event handler mappings for the application.
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected $listen = [];
+
+    /**
+     * Indicates if events should be discovered.
+     *
+     * @var bool
+     */
+    protected static $shouldDiscoverEvents = true;
+
+    /**
+     * Configure the proper event listeners for email verification.
+     */
+    protected function configureEmailVerification(): void
+    {
+        //
+    }
+}

--- a/Modules/Approval/App/Providers/RouteServiceProvider.php
+++ b/Modules/Approval/App/Providers/RouteServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Modules\Approval\App\Providers;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected string $name = 'Approval';
+
+    /**
+     * Called before routes are registered.
+     *
+     * Register any model bindings or pattern based filters.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     */
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     *
+     * These routes all receive session state, CSRF protection, etc.
+     */
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')->group(module_path($this->name, '/routes/web.php'));
+    }
+
+    /**
+     * Define the "api" routes for the application.
+     *
+     * These routes are typically stateless.
+     */
+    protected function mapApiRoutes(): void
+    {
+        Route::middleware('api')->prefix('api')->name('api.')->group(module_path($this->name, '/routes/api.php'));
+    }
+}

--- a/Modules/Approval/Database/migrations/2025_06_04_055101_create_approval_items_table.php
+++ b/Modules/Approval/Database/migrations/2025_06_04_055101_create_approval_items_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('approval_items', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('approval_items');
+    }
+};

--- a/Modules/Approval/Database/seeders/ApprovalDatabaseSeeder.php
+++ b/Modules/Approval/Database/seeders/ApprovalDatabaseSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Approval\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use RingleSoft\LaravelProcessApproval\ProcessApproval;
+use Spatie\Permission\Models\Role;
+use Modules\Approval\App\Models\ApprovalItem;
+
+class ApprovalDatabaseSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        try {
+            $flow = ProcessApproval::createFlow('Default ApprovalItem Flow', ApprovalItem::class);
+        } catch (\Throwable $e) {
+            $flow = ProcessApproval::flowsWithSteps()->firstWhere('approvable_type', ApprovalItem::class);
+        }
+
+        $role = Role::firstOrCreate(['name' => 'admin']);
+
+        if ($flow && !$flow->steps()->exists()) {
+            ProcessApproval::createStep($flow->id, $role->id);
+        }
+    }
+}

--- a/Modules/Approval/Database/seeders/ApprovalDatabaseSeeder.php
+++ b/Modules/Approval/Database/seeders/ApprovalDatabaseSeeder.php
@@ -20,10 +20,14 @@ class ApprovalDatabaseSeeder extends Seeder
             $flow = ProcessApproval::flowsWithSteps()->firstWhere('approvable_type', ApprovalItem::class);
         }
 
-        $role = Role::firstOrCreate(['name' => 'admin']);
+        $staffRole = Role::firstOrCreate(['name' => 'staff']);
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+        $superRole = Role::firstOrCreate(['name' => 'super-admin']);
 
         if ($flow && !$flow->steps()->exists()) {
-            ProcessApproval::createStep($flow->id, $role->id);
+            ProcessApproval::createStep($flow->id, $staffRole->id, \RingleSoft\LaravelProcessApproval\Enums\ApprovalTypeEnum::VERIFY);
+            ProcessApproval::createStep($flow->id, $adminRole->id);
+            ProcessApproval::createStep($flow->id, $superRole->id);
         }
     }
 }

--- a/Modules/Approval/composer.json
+++ b/Modules/Approval/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "nwidart/approval",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Approval\\": "app/",
+            "Modules\\Approval\\Database\\Factories\\": "database/factories/",
+            "Modules\\Approval\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Approval\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Approval/config/config.php
+++ b/Modules/Approval/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'name' => 'Approval',
+];

--- a/Modules/Approval/module.json
+++ b/Modules/Approval/module.json
@@ -1,0 +1,11 @@
+{
+  "name": "Approval",
+  "alias": "approval",
+  "description": "",
+  "keywords": [],
+  "priority": 0,
+  "providers": [
+    "Modules\\Approval\\App\\Providers\\ApprovalServiceProvider"
+  ],
+  "files": []
+}

--- a/Modules/Approval/package.json
+++ b/Modules/Approval/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "axios": "^1.1.2",
+    "laravel-vite-plugin": "^0.7.5",
+    "sass": "^1.69.5",
+    "postcss": "^8.3.7",
+    "vite": "^4.0.0"
+  }
+}

--- a/Modules/Approval/resources/views/create.blade.php
+++ b/Modules/Approval/resources/views/create.blade.php
@@ -1,0 +1,20 @@
+@extends('adminlte::page')
+@section('title', 'Create Approval Item')
+@section('content')
+<div class="card">
+    <div class="card-body">
+        <form method="POST" action="{{ route('approval.items.store') }}">
+            @csrf
+            <div class="mb-3">
+                <label for="title" class="form-label">Title</label>
+                <input type="text" name="title" id="title" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="description" class="form-label">Description</label>
+                <textarea name="description" id="description" class="form-control"></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/Modules/Approval/resources/views/edit.blade.php
+++ b/Modules/Approval/resources/views/edit.blade.php
@@ -1,0 +1,21 @@
+@extends('adminlte::page')
+@section('title', 'Edit Approval Item')
+@section('content')
+<div class="card">
+    <div class="card-body">
+        <form method="POST" action="{{ route('approval.items.update', $item) }}">
+            @csrf
+            @method('PUT')
+            <div class="mb-3">
+                <label for="title" class="form-label">Title</label>
+                <input type="text" name="title" id="title" class="form-control" value="{{ old('title', $item->title) }}" required>
+            </div>
+            <div class="mb-3">
+                <label for="description" class="form-label">Description</label>
+                <textarea name="description" id="description" class="form-control">{{ old('description', $item->description) }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Update</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/Modules/Approval/resources/views/index.blade.php
+++ b/Modules/Approval/resources/views/index.blade.php
@@ -8,6 +8,7 @@
     <thead>
         <tr>
             <th>Title</th>
+            <th>Status</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -15,6 +16,9 @@
     @foreach($items as $item)
         <tr>
             <td>{{ $item->title }}</td>
+            <td>
+                <x-ringlesoft-approval-status-summary :model="$item" />
+            </td>
             <td>
                 <a href="{{ route('approval.items.show', $item) }}" class="btn btn-info btn-sm">View</a>
                 <a href="{{ route('approval.items.edit', $item) }}" class="btn btn-secondary btn-sm">Edit</a>

--- a/Modules/Approval/resources/views/index.blade.php
+++ b/Modules/Approval/resources/views/index.blade.php
@@ -22,6 +22,7 @@
             <td>
                 <a href="{{ route('approval.items.show', $item) }}" class="btn btn-info btn-sm">View</a>
                 <a href="{{ route('approval.items.edit', $item) }}" class="btn btn-secondary btn-sm">Edit</a>
+                <x-ringlesoft-approval-actions :model="$item" class="d-inline" />
                 <form action="{{ route('approval.items.destroy', $item) }}" method="POST" class="d-inline">
                     @csrf
                     @method('DELETE')

--- a/Modules/Approval/resources/views/index.blade.php
+++ b/Modules/Approval/resources/views/index.blade.php
@@ -1,0 +1,31 @@
+@extends('adminlte::page')
+@section('title', 'Approval Items')
+@section('content')
+<div class="mb-3">
+    <a href="{{ route('approval.items.create') }}" class="btn btn-primary">New Item</a>
+</div>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($items as $item)
+        <tr>
+            <td>{{ $item->title }}</td>
+            <td>
+                <a href="{{ route('approval.items.show', $item) }}" class="btn btn-info btn-sm">View</a>
+                <a href="{{ route('approval.items.edit', $item) }}" class="btn btn-secondary btn-sm">Edit</a>
+                <form action="{{ route('approval.items.destroy', $item) }}" method="POST" class="d-inline">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Delete?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+    @endforeach
+    </tbody>
+</table>
+@endsection

--- a/Modules/Approval/resources/views/layouts/master.blade.php
+++ b/Modules/Approval/resources/views/layouts/master.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>Approval Module - {{ config('app.name', 'Laravel') }}</title>
+
+    <meta name="description" content="{{ $description ?? '' }}">
+    <meta name="keywords" content="{{ $keywords ?? '' }}">
+    <meta name="author" content="{{ $author ?? '' }}">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+    {{-- Vite CSS --}}
+    {{-- {{ module_vite('build-approval', 'resources/assets/sass/app.scss', storage_path('vite.hot')) }} --}}
+</head>
+
+<body>
+    @yield('content')
+
+    {{-- Vite JS --}}
+    {{-- {{ module_vite('build-approval', 'resources/assets/js/app.js', storage_path('vite.hot')) }} --}}
+</body>

--- a/Modules/Approval/resources/views/show.blade.php
+++ b/Modules/Approval/resources/views/show.blade.php
@@ -1,0 +1,11 @@
+@extends('adminlte::page')
+@section('title', $item->title)
+@section('content')
+<div class="card">
+    <div class="card-body">
+        <h4>{{ $item->title }}</h4>
+        <p>{{ $item->description }}</p>
+        <x-ringlesoft-approval-actions :model="$item" />
+    </div>
+</div>
+@endsection

--- a/Modules/Approval/resources/views/show.blade.php
+++ b/Modules/Approval/resources/views/show.blade.php
@@ -5,6 +5,7 @@
     <div class="card-body">
         <h4>{{ $item->title }}</h4>
         <p>{{ $item->description }}</p>
+        <x-ringlesoft-approval-status-summary :model="$item" class="mb-3" />
         <x-ringlesoft-approval-actions :model="$item" />
     </div>
 </div>

--- a/Modules/Approval/routes/api.php
+++ b/Modules/Approval/routes/api.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Approval\Http\Controllers\ApprovalController;
+
+/*
+ *--------------------------------------------------------------------------
+ * API Routes
+ *--------------------------------------------------------------------------
+ *
+ * Here is where you can register API routes for your application. These
+ * routes are loaded by the RouteServiceProvider within a group which
+ * is assigned the "api" middleware group. Enjoy building your API!
+ *
+*/
+
+Route::middleware(['auth:sanctum'])->prefix('v1')->group(function () {
+    Route::apiResource('approval', ApprovalController::class)->names('approval');
+});

--- a/Modules/Approval/routes/api.php
+++ b/Modules/Approval/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Modules\Approval\Http\Controllers\ApprovalController;
+use Modules\Approval\App\Http\Controllers\ApprovalController;
 
 /*
  *--------------------------------------------------------------------------

--- a/Modules/Approval/routes/web.php
+++ b/Modules/Approval/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Modules\Approval\Http\Controllers\ApprovalController;
+use Modules\Approval\App\Http\Controllers\ApprovalController;
 
 /*
 |--------------------------------------------------------------------------

--- a/Modules/Approval/routes/web.php
+++ b/Modules/Approval/routes/web.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Approval\Http\Controllers\ApprovalController;
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
+
+Route::group(['middleware' => ['web', 'auth'], 'prefix' => 'admin'], function () {
+    Route::resource('approval-items', ApprovalController::class)->names('approval.items');
+});

--- a/Modules/Approval/vite.config.js
+++ b/Modules/Approval/vite.config.js
@@ -1,0 +1,57 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import { readdirSync, statSync } from 'fs';
+import { join,relative,dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+export default defineConfig({
+    build: {
+        outDir: '../../public/build-approval',
+        emptyOutDir: true,
+        manifest: true,
+    },
+    plugins: [
+        laravel({
+            publicDirectory: '../../public',
+            buildDirectory: 'build-approval',
+            input: [
+                __dirname + '/resources/assets/sass/app.scss',
+                __dirname + '/resources/assets/js/app.js'
+            ],
+            refresh: true,
+        }),
+    ],
+});
+// Scen all resources for assets file. Return array
+//function getFilePaths(dir) {
+//    const filePaths = [];
+//
+//    function walkDirectory(currentPath) {
+//        const files = readdirSync(currentPath);
+//        for (const file of files) {
+//            const filePath = join(currentPath, file);
+//            const stats = statSync(filePath);
+//            if (stats.isFile() && !file.startsWith('.')) {
+//                const relativePath = 'Modules/Approval/'+relative(__dirname, filePath);
+//                filePaths.push(relativePath);
+//            } else if (stats.isDirectory()) {
+//                walkDirectory(filePath);
+//            }
+//        }
+//    }
+//
+//    walkDirectory(dir);
+//    return filePaths;
+//}
+
+//const __filename = fileURLToPath(import.meta.url);
+//const __dirname = dirname(__filename);
+
+//const assetsDir = join(__dirname, 'resources/assets');
+//export const paths = getFilePaths(assetsDir);
+
+
+//export const paths = [
+//    'Modules/Approval/resources/assets/sass/app.scss',
+//    'Modules/Approval/resources/assets/js/app.js',
+//];

--- a/Modules/Role/App/Models/User.php
+++ b/Modules/Role/App/Models/User.php
@@ -22,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'signature_path',
     ];
 
     /**
@@ -43,4 +44,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function getSignature(): ?string
+    {
+        return $this->signature_path;
+    }
 }

--- a/Modules/Role/Database/Migrations/2025_06_05_000001_add_signature_path_to_users_table.php
+++ b/Modules/Role/Database/Migrations/2025_06_05_000001_add_signature_path_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table) {
+            $table->string('signature_path')->nullable()->after('remember_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', static function (Blueprint $table) {
+            $table->dropColumn('signature_path');
+        });
+    }
+};

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravel/ui": "^4.5",
         "maatwebsite/excel": "^3.1",
         "nwidart/laravel-modules": "^11.0",
+        "ringlesoft/laravel-process-approval": "^1.1",
         "spatie/laravel-activitylog": "^4.10",
         "spatie/laravel-backup": "^8.8",
         "spatie/laravel-medialibrary": "^11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f35a29bb586909f2d72e62bc3bfad19b",
+    "content-hash": "125d2d26d860a0cd5aaa830e3a80ab34",
     "packages": [
         {
             "name": "almasaeed2010/adminlte",
@@ -4986,6 +4986,75 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "ringlesoft/laravel-process-approval",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ringlesoft/laravel-process-approval.git",
+                "reference": "4ad29a8aaf232fff29ee8d635cbf8bcbd3e3c8d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ringlesoft/laravel-process-approval/zipball/4ad29a8aaf232fff29ee8d635cbf8bcbd3e3c8d9",
+                "reference": "4ad29a8aaf232fff29ee8d635cbf8bcbd3e3c8d9",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/auth": "^10|^11|^12",
+                "illuminate/broadcasting": "^10|^11|^12",
+                "illuminate/database": "^10|^11|^12",
+                "illuminate/routing": "^10|^11|^12",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "roave/security-advisories": "dev-latest"
+            },
+            "type": "laravel-package",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "ProcessApproval": "RingleSoft\\LaravelProcessApproval\\Facade"
+                    },
+                    "providers": [
+                        "RingleSoft\\LaravelProcessApproval\\LaravelProcessApprovalServiceProvider"
+                    ],
+                    "dont-discover": []
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "RingleSoft\\LaravelProcessApproval\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Ringle",
+                    "email": "ringunger@gmail.com",
+                    "homepage": "https://ringlesoft.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A package to handle process approval flow in a laravel application.",
+            "homepage": "https://ringlesoft.com/packages/laravel-process-approval",
+            "keywords": [
+                "approval",
+                "approve",
+                "flow",
+                "laravel",
+                "procedure",
+                "ringlesoft"
+            ],
+            "support": {
+                "issues": "https://github.com/ringlesoft/laravel-process-approval/issues",
+                "source": "https://github.com/ringlesoft/laravel-process-approval/tree/1.1.1"
+            },
+            "time": "2025-04-03T09:30:16+00:00"
         },
         {
             "name": "spatie/db-dumper",
@@ -11149,12 +11218,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/config/process_approval.php
+++ b/config/process_approval.php
@@ -1,0 +1,38 @@
+<?php
+
+return [
+
+    /**
+     * This is the name of the table that contains the roles used to classify users
+     * (for spatie-laravel-permissions it is the `roles` table
+     */
+    'roles_model' => "\\Spatie\\Permission\\Models\\Role",
+
+
+    /**
+     * The model associated with login and authentication
+     */
+    'users_model' => "\\App\\Models\\User",
+
+
+    /**
+     * The Namespace in which application models ar located
+     */
+    'models_path' => "\\App\Models",
+
+    /**
+     * The middlewares that will be applied to the routes pointing to the approval controller
+     * 'web' is already applied by default
+     */
+    'approval_controller_middlewares' => [],
+
+    /**
+     * The name of the css library to use
+     */
+    'css_library' => 'tailwind', // tailwind | bootstrap |bootstrap3 | bootstrap4 | null
+
+    /**
+     * The name of the multi tenancy field in the users table
+     */
+    'multi_tenancy_field' => 'tenant_id',
+];

--- a/database/migrations/1_create_process_approval_flows_table.php
+++ b/database/migrations/1_create_process_approval_flows_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('process_approval_flows', static function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('approvable_type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('process_approval_flows');
+    }
+};

--- a/database/migrations/2_create_process_approval_flow_steps_table.php
+++ b/database/migrations/2_create_process_approval_flow_steps_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('process_approval_flow_steps', static function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('process_approval_flow_id')->constrained('process_approval_flows')->cascadeOnDelete();
+            $table->foreignId('role_id')->index();
+            $table->json('permissions')->nullable();
+            $table->integer('order')->nullable()->index();
+            $table->enum('action', ['APPROVE', 'VERIFY', 'CHECK'])->default('APPROVE');
+            $table->tinyInteger('active')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('process_approval_flow_steps');
+    }
+};

--- a/database/migrations/3_create_process_approvals_table.php
+++ b/database/migrations/3_create_process_approvals_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('process_approvals', static function (Blueprint $table) {
+            $table->id();
+            $table->morphs('approvable');
+            $table->foreignId('process_approval_flow_step_id')->nullable()->constrained('process_approval_flow_steps')->cascadeOnDelete();
+            $table->string('approval_action', 12)->default('Approved');
+            $table->text('approver_name')->nullable();
+            $table->text('comment')->nullable();
+            $table->foreignId('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('process_approvals');
+    }
+};

--- a/database/migrations/4_create_process_approval_statuses_table.php
+++ b/database/migrations/4_create_process_approval_statuses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use RingleSoft\LaravelProcessApproval\Enums\ApprovalStatusEnum;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('process_approval_statuses', static function (Blueprint $table) {
+            $table->id();
+            $table->morphs('approvable');
+            $table->json('steps')->nullable();
+            $table->string('status', 10)->default(ApprovalStatusEnum::CREATED->value);
+            $table->foreignId('creator_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('process_approval_statuses');
+    }
+};

--- a/database/migrations/5_add_tenant_ids_to_approval_tables.php
+++ b/database/migrations/5_add_tenant_ids_to_approval_tables.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('process_approval_flow_steps', static function (Blueprint $table) {
+            $table->string('tenant_id', 38)->index()->nullable()->after('active');
+        });
+        Schema::table('process_approvals', static function (Blueprint $table) {
+            $table->string('tenant_id', 38)->index()->nullable()->after('user_id');
+        });
+        Schema::table('process_approval_statuses', static function (Blueprint $table) {
+            $table->string('tenant_id', 38)->index()->nullable()->after('creator_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if(Schema::hasColumn('process_approval_flow_steps', 'tenant_id')) {
+            Schema::table('process_approval_flow_steps', static function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
+        if(Schema::hasColumn('process_approvals', 'tenant_id')) {
+            Schema::table('process_approvals', static function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
+        if(Schema::hasColumn('process_approval_statuses', 'tenant_id')) {
+            Schema::table('process_approval_statuses', static function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
+    }
+};

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -12,5 +12,6 @@
     "ExcelManager": true,
     "LatexManager": true,
     "SettingManager": true,
-    "EmailManager": true
+    "EmailManager": true,
+    "Approval": true
 }


### PR DESCRIPTION
## Summary
- install `ringlesoft/laravel-process-approval`
- publish approval config and migrations
- create new `Approval` module with model, controller, routes and views
- implement database seeder and migration for approval items

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_683fdd3ba76c832dbf47fb536f424e0f