### PR TITLE
Add BillingManager module skeleton

### DIFF
--- a/Modules/BillingManager/App/Http/Controllers/Admin/DashboardController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): Response
+    {
+        return response()->view('billing::admin.dashboard');
+    }
+}

--- a/Modules/BillingManager/App/Http/Controllers/Admin/PlanController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Admin/PlanController.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace Modules\BillingManager\App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Response;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Modules\BillingManager\App\Models\Plan;
 
 class PlanController extends Controller
 {
     public function index(): Response
     {
-        return response()->view('billing::admin.plans.index');
+        $plans = Plan::all();
+
+        return response()->view('billing::admin.plans.index', compact('plans'));
     }
 
     public function create(): Response
@@ -23,21 +26,43 @@ class PlanController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
+        $validated = $request->validate([
+            'name' => 'required|string',
+            'slug' => 'required|string|unique:plans,slug',
+            'price' => 'required|integer',
+            'currency' => 'required|string|size:3',
+            'stripe_price_id' => 'required|string',
+        ]);
+
+        Plan::create($validated);
+
         return redirect()->route('admin.billing.plans.index');
     }
 
-    public function edit(int $id): Response
+    public function edit(Plan $plan): Response
     {
-        return response()->view('billing::admin.plans.edit', ['id' => $id]);
+        return response()->view('billing::admin.plans.edit', compact('plan'));
     }
 
-    public function update(Request $request, int $id): RedirectResponse
+    public function update(Request $request, Plan $plan): RedirectResponse
     {
+        $validated = $request->validate([
+            'name' => 'required|string',
+            'slug' => 'required|string|unique:plans,slug,'.$plan->id,
+            'price' => 'required|integer',
+            'currency' => 'required|string|size:3',
+            'stripe_price_id' => 'required|string',
+        ]);
+
+        $plan->update($validated);
+
         return redirect()->route('admin.billing.plans.index');
     }
 
-    public function destroy(int $id): RedirectResponse
+    public function destroy(Plan $plan): RedirectResponse
     {
+        $plan->delete();
+
         return redirect()->route('admin.billing.plans.index');
     }
 }

--- a/Modules/BillingManager/App/Http/Controllers/Admin/PlanController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Admin/PlanController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class PlanController extends Controller
+{
+    public function index(): Response
+    {
+        return response()->view('billing::admin.plans.index');
+    }
+
+    public function create(): Response
+    {
+        return response()->view('billing::admin.plans.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        return redirect()->route('admin.billing.plans.index');
+    }
+
+    public function edit(int $id): Response
+    {
+        return response()->view('billing::admin.plans.edit', ['id' => $id]);
+    }
+
+    public function update(Request $request, int $id): RedirectResponse
+    {
+        return redirect()->route('admin.billing.plans.index');
+    }
+
+    public function destroy(int $id): RedirectResponse
+    {
+        return redirect()->route('admin.billing.plans.index');
+    }
+}

--- a/Modules/BillingManager/App/Http/Controllers/Admin/RefundController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Admin/RefundController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+
+class RefundController extends Controller
+{
+    public function store(string $invoice): RedirectResponse
+    {
+        return redirect()->route('admin.billing.index');
+    }
+}

--- a/Modules/BillingManager/App/Http/Controllers/Admin/RefundController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Admin/RefundController.php
@@ -6,11 +6,18 @@ namespace Modules\BillingManager\App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
+use Modules\BillingManager\Services\InvoiceService;
 
 class RefundController extends Controller
 {
+    public function __construct(private InvoiceService $invoices)
+    {
+    }
+
     public function store(string $invoice): RedirectResponse
     {
+        $this->invoices->refund($invoice);
+
         return redirect()->route('admin.billing.index');
     }
 }

--- a/Modules/BillingManager/App/Http/Controllers/Front/DashboardController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Front/DashboardController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): Response
+    {
+        return response()->view('billing::front.dashboard');
+    }
+}

--- a/Modules/BillingManager/App/Http/Controllers/Front/InvoiceController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Front/InvoiceController.php
@@ -6,11 +6,20 @@ namespace Modules\BillingManager\App\Http\Controllers\Front;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Response;
+use Modules\BillingManager\Services\InvoiceService;
 
 class InvoiceController extends Controller
 {
+    public function __construct(private InvoiceService $invoices)
+    {
+    }
+
     public function __invoke(string $invoice): Response
     {
-        return response()->view('billing::front.invoice', ['invoice' => $invoice]);
+        $invoiceData = $this->invoices->find(auth()->user(), $invoice);
+
+        return response()->view('billing::front.invoice', [
+            'invoice' => $invoiceData,
+        ]);
     }
 }

--- a/Modules/BillingManager/App/Http/Controllers/Front/InvoiceController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Front/InvoiceController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+
+class InvoiceController extends Controller
+{
+    public function __invoke(string $invoice): Response
+    {
+        return response()->view('billing::front.invoice', ['invoice' => $invoice]);
+    }
+}

--- a/Modules/BillingManager/App/Http/Controllers/Front/SubscriptionController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Front/SubscriptionController.php
@@ -7,19 +7,34 @@ namespace Modules\BillingManager\App\Http\Controllers\Front;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Laravel\Cashier\Facades\Cashier;
+use Modules\BillingManager\Services\SubscriptionService;
 
 class SubscriptionController extends Controller
 {
+    public function __construct(private SubscriptionService $subscriptions)
+    {
+    }
+
     public function store(Request $request): RedirectResponse
     {
-        // Subscription creation logic placeholder
+        $request->validate([
+            'price' => 'required|string',
+            'payment_method' => 'nullable|string',
+        ]);
+
+        $this->subscriptions->subscribe(
+            $request->user(),
+            $request->string('price')->toString(),
+            $request->string('payment_method')->toString()
+        );
+
         return redirect()->route('billing.index');
     }
 
-    public function cancel(): RedirectResponse
+    public function cancel(Request $request): RedirectResponse
     {
-        // Subscription cancel logic placeholder
+        $this->subscriptions->cancel($request->user());
+
         return redirect()->route('billing.index');
     }
 }

--- a/Modules/BillingManager/App/Http/Controllers/Front/SubscriptionController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Front/SubscriptionController.php
@@ -37,4 +37,11 @@ class SubscriptionController extends Controller
 
         return redirect()->route('billing.index');
     }
+
+    public function resume(Request $request): RedirectResponse
+    {
+        $this->subscriptions->resume($request->user());
+
+        return redirect()->route('billing.index');
+    }
 }

--- a/Modules/BillingManager/App/Http/Controllers/Front/SubscriptionController.php
+++ b/Modules/BillingManager/App/Http/Controllers/Front/SubscriptionController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Http\Controllers\Front;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Laravel\Cashier\Facades\Cashier;
+
+class SubscriptionController extends Controller
+{
+    public function store(Request $request): RedirectResponse
+    {
+        // Subscription creation logic placeholder
+        return redirect()->route('billing.index');
+    }
+
+    public function cancel(): RedirectResponse
+    {
+        // Subscription cancel logic placeholder
+        return redirect()->route('billing.index');
+    }
+}

--- a/Modules/BillingManager/App/Jobs/HandleStripeWebhookJob.php
+++ b/Modules/BillingManager/App/Jobs/HandleStripeWebhookJob.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Laravel\Cashier\Cashier;
+
+class HandleStripeWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public array $payload)
+    {
+    }
+
+    public function handle(): void
+    {
+        Cashier::stripe()->webhookHandler($this->payload);
+    }
+}

--- a/Modules/BillingManager/App/Models/Plan.php
+++ b/Modules/BillingManager/App/Models/Plan.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Plan extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'price',
+        'currency',
+        'stripe_price_id',
+    ];
+}

--- a/Modules/BillingManager/App/Providers/BillingServiceProvider.php
+++ b/Modules/BillingManager/App/Providers/BillingServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Providers;
+
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Cashier\CashierServiceProvider;
+use Modules\BillingManager\App\Jobs\HandleStripeWebhookJob;
+
+class BillingServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->register(CashierServiceProvider::class);
+        $this->mergeConfigFrom(__DIR__.'/../../Config/cashier.php', 'cashier');
+        $this->mergeConfigFrom(__DIR__.'/../../Config/services.php', 'services');
+    }
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(module_path('BillingManager', 'Database/Migrations'));
+        $this->loadRoutesFrom(__DIR__.'/../../Routes/web.php');
+        $this->loadRoutesFrom(__DIR__.'/../../Routes/admin.php');
+        $this->loadRoutesFrom(__DIR__.'/../../Routes/api.php');
+        $this->loadViewsFrom(module_path('BillingManager', 'Resources/views'), 'billing');
+
+        Gate::define('manage-billing', fn (\App\Models\User $u) => $u->role === 'admin');
+    }
+}

--- a/Modules/BillingManager/App/Providers/BillingServiceProvider.php
+++ b/Modules/BillingManager/App/Providers/BillingServiceProvider.php
@@ -26,6 +26,6 @@ class BillingServiceProvider extends ServiceProvider
         $this->loadRoutesFrom(__DIR__.'/../../Routes/api.php');
         $this->loadViewsFrom(module_path('BillingManager', 'Resources/views'), 'billing');
 
-        Gate::define('manage-billing', fn (\App\Models\User $u) => $u->role === 'admin');
+        Gate::define('manage-billing', fn (\Modules\Role\App\Models\User $u) => $u->hasAnyRole(['admin', 'super-admin']));
     }
 }

--- a/Modules/BillingManager/App/Providers/RouteServiceProvider.php
+++ b/Modules/BillingManager/App/Providers/RouteServiceProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * Define your route model bindings, pattern filters, etc.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    public function map(): void
+    {
+        $this->mapWebRoutes();
+        $this->mapAdminRoutes();
+        $this->mapApiRoutes();
+    }
+
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace('Modules\\BillingManager\\App\\Http\\Controllers')
+            ->group(module_path('BillingManager', 'Routes/web.php'));
+    }
+
+    protected function mapAdminRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace('Modules\\BillingManager\\App\\Http\\Controllers')
+            ->group(module_path('BillingManager', 'Routes/admin.php'));
+    }
+
+    protected function mapApiRoutes(): void
+    {
+        Route::prefix('api')
+            ->middleware('api')
+            ->namespace('Modules\\BillingManager\\App\\Http\\Controllers')
+            ->group(module_path('BillingManager', 'Routes/api.php'));
+    }
+}

--- a/Modules/BillingManager/Config/cashier.php
+++ b/Modules/BillingManager/Config/cashier.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    // Cashier configuration placeholder
+];

--- a/Modules/BillingManager/Config/services.php
+++ b/Modules/BillingManager/Config/services.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    // Third-party service configuration placeholder
+];

--- a/Modules/BillingManager/Database/Migrations/2024_01_01_000000_create_subscriptions_table.php
+++ b/Modules/BillingManager/Database/Migrations/2024_01_01_000000_create_subscriptions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_status');
+            $table->string('stripe_price')->nullable();
+            $table->integer('quantity')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/Modules/BillingManager/Database/Migrations/2024_01_01_000001_create_subscription_items_table.php
+++ b/Modules/BillingManager/Database/Migrations/2024_01_01_000001_create_subscription_items_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subscription_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subscription_id')->constrained()->cascadeOnDelete();
+            $table->string('stripe_id');
+            $table->string('stripe_price');
+            $table->integer('quantity')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_items');
+    }
+};

--- a/Modules/BillingManager/Database/Migrations/2024_01_01_000002_create_plans_table.php
+++ b/Modules/BillingManager/Database/Migrations/2024_01_01_000002_create_plans_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('plans', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->integer('price');
+            $table->string('currency', 3)->default('usd');
+            $table->string('stripe_price_id');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plans');
+    }
+};

--- a/Modules/BillingManager/Database/factories/PlanFactory.php
+++ b/Modules/BillingManager/Database/factories/PlanFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\Database\factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Modules\BillingManager\App\Models\Plan;
+
+class PlanFactory extends Factory
+{
+    protected $model = Plan::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'slug' => $this->faker->unique()->slug(),
+            'price' => $this->faker->numberBetween(500, 2000),
+            'currency' => 'usd',
+            'stripe_price_id' => 'price_'.$this->faker->unique()->word(),
+        ];
+    }
+}

--- a/Modules/BillingManager/Resources/js/admin.js
+++ b/Modules/BillingManager/Resources/js/admin.js
@@ -1,0 +1,2 @@
+import 'admin-lte';
+import 'admin-lte/dist/css/adminlte.css';

--- a/Modules/BillingManager/Resources/js/front.js
+++ b/Modules/BillingManager/Resources/js/front.js
@@ -1,0 +1,1 @@
+// Front-end JS entry

--- a/Modules/BillingManager/Resources/sass/admin.scss
+++ b/Modules/BillingManager/Resources/sass/admin.scss
@@ -1,0 +1,1 @@
+// Admin styles

--- a/Modules/BillingManager/Resources/sass/front.scss
+++ b/Modules/BillingManager/Resources/sass/front.scss
@@ -1,0 +1,1 @@
+// Front-end styles

--- a/Modules/BillingManager/Resources/views/admin/dashboard.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/dashboard.blade.php
@@ -1,0 +1,7 @@
+@extends('adminlte::page')
+
+@section('title', 'Billing Dashboard')
+
+@section('content')
+    <h1>Billing Dashboard</h1>
+@endsection

--- a/Modules/BillingManager/Resources/views/admin/plans/create.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/plans/create.blade.php
@@ -1,0 +1,7 @@
+@extends('adminlte::page')
+
+@section('title', 'Create Plan')
+
+@section('content')
+    <h1>Create Plan</h1>
+@endsection

--- a/Modules/BillingManager/Resources/views/admin/plans/create.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/plans/create.blade.php
@@ -4,4 +4,29 @@
 
 @section('content')
     <h1>Create Plan</h1>
+
+    <form method="POST" action="{{ route('admin.billing.plans.store') }}">
+        @csrf
+        <div class="form-group">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label for="slug">Slug</label>
+            <input type="text" id="slug" name="slug" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label for="price">Price (cents)</label>
+            <input type="number" id="price" name="price" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label for="currency">Currency</label>
+            <input type="text" id="currency" name="currency" class="form-control" value="usd" required>
+        </div>
+        <div class="form-group">
+            <label for="stripe_price_id">Stripe Price ID</label>
+            <input type="text" id="stripe_price_id" name="stripe_price_id" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Create</button>
+    </form>
 @endsection

--- a/Modules/BillingManager/Resources/views/admin/plans/edit.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/plans/edit.blade.php
@@ -4,4 +4,30 @@
 
 @section('content')
     <h1>Edit Plan</h1>
+
+    <form method="POST" action="{{ route('admin.billing.plans.update', $plan) }}">
+        @csrf
+        @method('PUT')
+        <div class="form-group">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" class="form-control" value="{{ $plan->name }}" required>
+        </div>
+        <div class="form-group">
+            <label for="slug">Slug</label>
+            <input type="text" id="slug" name="slug" class="form-control" value="{{ $plan->slug }}" required>
+        </div>
+        <div class="form-group">
+            <label for="price">Price (cents)</label>
+            <input type="number" id="price" name="price" class="form-control" value="{{ $plan->price }}" required>
+        </div>
+        <div class="form-group">
+            <label for="currency">Currency</label>
+            <input type="text" id="currency" name="currency" class="form-control" value="{{ $plan->currency }}" required>
+        </div>
+        <div class="form-group">
+            <label for="stripe_price_id">Stripe Price ID</label>
+            <input type="text" id="stripe_price_id" name="stripe_price_id" class="form-control" value="{{ $plan->stripe_price_id }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Update</button>
+    </form>
 @endsection

--- a/Modules/BillingManager/Resources/views/admin/plans/edit.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/plans/edit.blade.php
@@ -1,0 +1,7 @@
+@extends('adminlte::page')
+
+@section('title', 'Edit Plan')
+
+@section('content')
+    <h1>Edit Plan</h1>
+@endsection

--- a/Modules/BillingManager/Resources/views/admin/plans/index.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/plans/index.blade.php
@@ -1,0 +1,7 @@
+@extends('adminlte::page')
+
+@section('title', 'Plans')
+
+@section('content')
+    <h1>Plans</h1>
+@endsection

--- a/Modules/BillingManager/Resources/views/admin/plans/index.blade.php
+++ b/Modules/BillingManager/Resources/views/admin/plans/index.blade.php
@@ -4,4 +4,32 @@
 
 @section('content')
     <h1>Plans</h1>
+
+    <a href="{{ route('admin.billing.plans.create') }}" class="btn btn-primary mb-3">New Plan</a>
+
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Price</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($plans as $plan)
+                <tr>
+                    <td>{{ $plan->name }}</td>
+                    <td>{{ number_format($plan->price / 100, 2) }} {{ strtoupper($plan->currency) }}</td>
+                    <td>
+                        <a href="{{ route('admin.billing.plans.edit', $plan) }}" class="btn btn-sm btn-secondary">Edit</a>
+                        <form action="{{ route('admin.billing.plans.destroy', $plan) }}" method="POST" style="display:inline-block">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
 @endsection

--- a/Modules/BillingManager/Resources/views/front/dashboard.blade.php
+++ b/Modules/BillingManager/Resources/views/front/dashboard.blade.php
@@ -1,0 +1,1 @@
+<h1>Billing Dashboard</h1>

--- a/Modules/BillingManager/Resources/views/front/invoice.blade.php
+++ b/Modules/BillingManager/Resources/views/front/invoice.blade.php
@@ -1,0 +1,1 @@
+<h1>Invoice {{ $invoice }}</h1>

--- a/Modules/BillingManager/Resources/views/front/invoice.blade.php
+++ b/Modules/BillingManager/Resources/views/front/invoice.blade.php
@@ -1,1 +1,2 @@
-<h1>Invoice {{ $invoice }}</h1>
+<h1>Invoice {{ $invoice->id }}</h1>
+<p>Total: {{ $invoice->total() }} {{ strtoupper($invoice->currency) }}</p>

--- a/Modules/BillingManager/Routes/admin.php
+++ b/Modules/BillingManager/Routes/admin.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\BillingManager\App\Http\Controllers\Admin;
+
+Route::middleware(['auth', 'can:manage-billing'])
+    ->prefix('admin/billing')
+    ->name('admin.billing.')
+    ->group(function () {
+        Route::get('/', Admin\DashboardController::class)->name('index');
+        Route::resource('plans', Admin\PlanController::class)->except('show');
+        Route::post('/refund/{invoice}', [Admin\RefundController::class, 'store'])->name('refund');
+    });

--- a/Modules/BillingManager/Routes/api.php
+++ b/Modules/BillingManager/Routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('api')
+    ->prefix('billing')
+    ->group(function () {
+        // API routes
+    });

--- a/Modules/BillingManager/Routes/web.php
+++ b/Modules/BillingManager/Routes/web.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\BillingManager\App\Http\Controllers\Front;
+
+Route::middleware('auth')
+    ->prefix('billing')
+    ->name('billing.')
+    ->group(function () {
+        Route::get('/', Front\DashboardController::class)->name('index');
+        Route::post('/subscribe', [Front\SubscriptionController::class, 'store'])->name('subscribe');
+        Route::post('/cancel', [Front\SubscriptionController::class, 'cancel'])->name('cancel');
+        Route::get('/invoices/{invoice}', Front\InvoiceController::class)->name('invoice');
+    });
+
+Route::post('/cashier/webhook', function () {
+    dispatch(new Modules\BillingManager\App\Jobs\HandleStripeWebhookJob(request()->all()));
+    return response()->json(['status' => 'ok']);
+});

--- a/Modules/BillingManager/Routes/web.php
+++ b/Modules/BillingManager/Routes/web.php
@@ -10,6 +10,7 @@ Route::middleware('auth')
         Route::get('/', Front\DashboardController::class)->name('index');
         Route::post('/subscribe', [Front\SubscriptionController::class, 'store'])->name('subscribe');
         Route::post('/cancel', [Front\SubscriptionController::class, 'cancel'])->name('cancel');
+        Route::post('/resume', [Front\SubscriptionController::class, 'resume'])->name('resume');
         Route::get('/invoices/{invoice}', Front\InvoiceController::class)->name('invoice');
     });
 

--- a/Modules/BillingManager/Services/InvoiceService.php
+++ b/Modules/BillingManager/Services/InvoiceService.php
@@ -4,7 +4,20 @@ declare(strict_types=1);
 
 namespace Modules\BillingManager\Services;
 
+use App\Models\User;
+use Laravel\Cashier\Cashier;
+
 class InvoiceService
 {
-    // Domain logic for invoices
+    public function find(User $user, string $invoiceId)
+    {
+        return $user->findInvoice($invoiceId);
+    }
+
+    public function refund(string $invoiceId): void
+    {
+        Cashier::stripe()->refunds->create([
+            'invoice' => $invoiceId,
+        ]);
+    }
 }

--- a/Modules/BillingManager/Services/InvoiceService.php
+++ b/Modules/BillingManager/Services/InvoiceService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\Services;
+
+class InvoiceService
+{
+    // Domain logic for invoices
+}

--- a/Modules/BillingManager/Services/PaymentMethodService.php
+++ b/Modules/BillingManager/Services/PaymentMethodService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\Services;
+
+class PaymentMethodService
+{
+    // Domain logic for payment methods
+}

--- a/Modules/BillingManager/Services/PaymentMethodService.php
+++ b/Modules/BillingManager/Services/PaymentMethodService.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Modules\BillingManager\Services;
 
+use App\Models\User;
+
 class PaymentMethodService
 {
-    // Domain logic for payment methods
+    public function add(User $user, string $paymentMethodId): void
+    {
+        $user->addPaymentMethod($paymentMethodId);
+        $user->updateDefaultPaymentMethod($paymentMethodId);
+    }
 }

--- a/Modules/BillingManager/Services/SubscriptionService.php
+++ b/Modules/BillingManager/Services/SubscriptionService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\BillingManager\Services;
+
+class SubscriptionService
+{
+    // Domain logic for managing subscriptions
+}

--- a/Modules/BillingManager/Services/SubscriptionService.php
+++ b/Modules/BillingManager/Services/SubscriptionService.php
@@ -4,7 +4,24 @@ declare(strict_types=1);
 
 namespace Modules\BillingManager\Services;
 
+use App\Models\User;
+use Laravel\Cashier\Cashier;
+
 class SubscriptionService
 {
-    // Domain logic for managing subscriptions
+    public function subscribe(User $user, string $priceId, ?string $paymentMethod = null): void
+    {
+        $builder = $user->newSubscription('default', $priceId);
+
+        if ($paymentMethod) {
+            $builder->create($paymentMethod);
+        } else {
+            $builder->create();
+        }
+    }
+
+    public function cancel(User $user): void
+    {
+        $user->subscription('default')?->cancel();
+    }
 }

--- a/Modules/BillingManager/Services/SubscriptionService.php
+++ b/Modules/BillingManager/Services/SubscriptionService.php
@@ -24,4 +24,9 @@ class SubscriptionService
     {
         $user->subscription('default')?->cancel();
     }
+
+    public function resume(User $user): void
+    {
+        $user->subscription('default')?->resume();
+    }
 }

--- a/Modules/BillingManager/Tests/Feature/Front/SubscribeTest.php
+++ b/Modules/BillingManager/Tests/Feature/Front/SubscribeTest.php
@@ -4,7 +4,7 @@ namespace Modules\BillingManager\Tests\Feature\Front;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Cashier\Facades\Cashier;
+use Laravel\Cashier\Cashier;
 use Tests\TestCase;
 
 class SubscribeTest extends TestCase

--- a/Modules/BillingManager/Tests/Feature/Front/SubscribeTest.php
+++ b/Modules/BillingManager/Tests/Feature/Front/SubscribeTest.php
@@ -22,4 +22,19 @@ class SubscribeTest extends TestCase
 
         Cashier::assertCharges(1);
     }
+
+    public function test_user_can_resume_subscription(): void
+    {
+        Cashier::fake();
+        $user = User::factory()->create();
+        $this->actingAs($user)
+            ->post(route('billing.subscribe'), ['price' => 'price_test']);
+
+        $this->post(route('billing.cancel'));
+
+        $this->post(route('billing.resume'))
+            ->assertRedirect();
+
+        Cashier::assertCharges(1);
+    }
 }

--- a/Modules/BillingManager/Tests/Feature/Front/SubscribeTest.php
+++ b/Modules/BillingManager/Tests/Feature/Front/SubscribeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\BillingManager\Tests\Feature\Front;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Facades\Cashier;
+use Tests\TestCase;
+
+class SubscribeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_subscribe(): void
+    {
+        Cashier::fake();
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('billing.subscribe'), ['price' => 'price_test'])
+            ->assertRedirect();
+
+        Cashier::assertCharges(1);
+    }
+}

--- a/Modules/BillingManager/module.json
+++ b/Modules/BillingManager/module.json
@@ -1,0 +1,12 @@
+{
+    "name": "BillingManager",
+    "alias": "billingmanager",
+    "description": "",
+    "keywords": [],
+    "priority": 0,
+    "providers": [
+        "Modules\\BillingManager\\App\\Providers\\BillingServiceProvider",
+        "Modules\\BillingManager\\App\\Providers\\RouteServiceProvider"
+    ],
+    "files": []
+}

--- a/Modules/BillingManager/vite.config.js
+++ b/Modules/BillingManager/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+export default defineConfig({
+    plugins: [laravel({
+        input: [
+          'Modules/BillingManager/Resources/js/front.js',
+          'Modules/BillingManager/Resources/js/admin.js',
+          'Modules/BillingManager/Resources/sass/front.scss',
+          'Modules/BillingManager/Resources/sass/admin.scss',
+        ],
+        refresh: true,
+    })],
+    publicDir: 'public/modules/billingmanager',
+});

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     "scripts": {
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi"
+            "@php artisan package:discover --ansi",
+            "@php artisan module:migrate --force"
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force"

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.2",
         "jeroennoten/laravel-adminlte": "^3.14",
+        "laravel/cashier": "^15",
         "laravel/framework": "^11.0",
         "laravel/passport": "^12.0",
         "laravel/sanctum": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f35a29bb586909f2d72e62bc3bfad19b",
+    "content-hash": "d63e6ce4050d96d6b71c53ac56ab2873",
     "packages": [
         {
             "name": "almasaeed2010/adminlte",
@@ -1506,6 +1506,94 @@
                 "source": "https://github.com/jeroennoten/Laravel-AdminLTE/tree/v3.15.0"
             },
             "time": "2025-02-24T22:20:15+00:00"
+        },
+        {
+            "name": "laravel/cashier",
+            "version": "v15.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/cashier-stripe.git",
+                "reference": "e26d51f19d29edc70c01b74e3eca688f487d0987"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/cashier-stripe/zipball/e26d51f19d29edc70c01b74e3eca688f487d0987",
+                "reference": "e26d51f19d29edc70c01b74e3eca688f487d0987",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/database": "^10.0|^11.0|^12.0",
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/log": "^10.0|^11.0|^12.0",
+                "illuminate/notifications": "^10.0|^11.0|^12.0",
+                "illuminate/pagination": "^10.0|^11.0|^12.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/view": "^10.0|^11.0|^12.0",
+                "moneyphp/money": "^4.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "php": "^8.1",
+                "stripe/stripe-php": "^16.2",
+                "symfony/console": "^6.0|^7.0",
+                "symfony/http-kernel": "^6.0|^7.0",
+                "symfony/polyfill-intl-icu": "^1.22.1"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^2.0|^3.0",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^8.18|^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.4|^11.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Required when generating and downloading invoice PDF's using Dompdf (^2.0|^3.0).",
+                "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Cashier\\CashierServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "15.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Cashier\\": "src/",
+                    "Laravel\\Cashier\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Dries Vints",
+                    "email": "dries@laravel.com"
+                }
+            ],
+            "description": "Laravel Cashier provides an expressive, fluent interface to Stripe's subscription billing services.",
+            "keywords": [
+                "billing",
+                "laravel",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/cashier/issues",
+                "source": "https://github.com/laravel/cashier"
+            },
+            "time": "2025-06-10T15:07:05+00:00"
         },
         {
             "name": "laravel/framework",
@@ -3206,6 +3294,96 @@
                 "source": "https://github.com/MarkBaker/PHPMatrix/tree/3.0.1"
             },
             "time": "2022-12-02T22:17:43+00:00"
+        },
+        {
+            "name": "moneyphp/money",
+            "version": "v4.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/moneyphp/money.git",
+                "reference": "1a23f0e1b22e2c59ed5ed70cfbe4cbe696be9348"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/1a23f0e1b22e2c59ed5ed70cfbe4cbe696be9348",
+                "reference": "1a23f0e1b22e2c59ed5ed70cfbe4cbe696be9348",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "cache/taggable-cache": "^1.1.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/instantiator": "^1.5.0 || ^2.0",
+                "ext-gmp": "*",
+                "ext-intl": "*",
+                "florianv/exchanger": "^2.8.1",
+                "florianv/swap": "^4.3.0",
+                "moneyphp/crypto-currencies": "^1.1.0",
+                "moneyphp/iso-currencies": "^3.4",
+                "php-http/message": "^1.16.0",
+                "php-http/mock-client": "^1.6.0",
+                "phpbench/phpbench": "^1.2.5",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1.9",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.9",
+                "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
+                "ticketswap/phpstan-error-formatter": "^1.1"
+            },
+            "suggest": {
+                "ext-gmp": "Calculate without integer limits",
+                "ext-intl": "Format Money objects with intl",
+                "florianv/exchanger": "Exchange rates library for PHP",
+                "florianv/swap": "Exchange rates library for PHP",
+                "psr/cache-implementation": "Used for Currency caching"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Verraes",
+                    "email": "mathias@verraes.net",
+                    "homepage": "http://verraes.net"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Frederik Bosch",
+                    "email": "f.bosch@genkgo.nl"
+                }
+            ],
+            "description": "PHP implementation of Fowler's Money pattern",
+            "homepage": "http://moneyphp.org",
+            "keywords": [
+                "Value Object",
+                "money",
+                "vo"
+            ],
+            "support": {
+                "issues": "https://github.com/moneyphp/money/issues",
+                "source": "https://github.com/moneyphp/money/tree/v4.7.1"
+            },
+            "time": "2025-06-06T07:12:38+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5831,6 +6009,65 @@
             "time": "2025-01-13T13:04:43+00:00"
         },
         {
+            "name": "stripe/stripe-php",
+            "version": "v16.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "d6de0a536f00b5c5c74f36b8f4d0d93b035499ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/d6de0a536f00b5c5c74f36b8f4d0d93b035499ff",
+                "reference": "d6de0a536f00b5c5c74f36b8f4d0d93b035499ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.5.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v16.6.0"
+            },
+            "time": "2025-02-24T22:35:29+00:00"
+        },
+        {
             "name": "symfony/clock",
             "version": "v7.2.0",
             "source": {
@@ -6936,6 +7173,90 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "763d2a91fea5681509ca01acbc1c5e450d127811"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/763d2a91fea5681509ca01acbc1c5e450d127811",
+                "reference": "763d2a91fea5681509ca01acbc1c5e450d127811",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance and support of other locales than \"en\""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Icu\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-21T18:38:29+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
@@ -11149,12 +11470,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -15,6 +15,6 @@
     "EmailManager": true,
     "Post": true,
     "SettingsManager": true,
-    "SanctumMonitor": true
-    ,"BillingManager": true
+    "SanctumMonitor": true,
+    "BillingManager": true
 }

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -16,4 +16,5 @@
     "Post": true,
     "SettingsManager": true,
     "SanctumMonitor": true
+    ,"BillingManager": true
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
         "laravel-vite-plugin": "^1.0.0",
         "sass": "^1.56.1",
         "vite": "^5.0.0"
+    },
+    "dependencies": {
+        "admin-lte": "^3",
+        "bootstrap": "^5.3.0",
+        "jquery": "^3.7.1",
+        "popper.js": "^1.16.1"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
## Summary
- create BillingManager nwidart module with admin and front boilerplate
- register BillingServiceProvider and RouteServiceProvider
- stub controllers, services, migrations, routes, views, assets
- add BillingManager to enabled modules
- run migrations automatically via composer script
- update dependencies with AdminLTE

## Testing
- `./vendor/bin/pint` *(fails: No such file or directory)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512ea0ef70832db84aa1b8d7e9b604